### PR TITLE
Simplify arXiv record category parsing logic

### DIFF
--- a/services/parse_arxiv_summaries/src/parse_arxiv_summaries/lambda_handler.py
+++ b/services/parse_arxiv_summaries/src/parse_arxiv_summaries/lambda_handler.py
@@ -234,7 +234,8 @@ def parse_xml_data(xml_data: str) -> list:
             categories = [CS_CATEGORIES_INVERTED.get(subject.text, "") for subject in subjects_elements]
             # Remove empty strings
             categories = list(filter(None, categories))
-            primary_category = categories[0] if categories else ""
+            if not categories:
+                categories.append("NULL")
 
             abstract = record.find(".//dc:description", ns).text.replace("\n", " ")
             title = record.find(".//dc:title", ns).text.replace("\n", "")
@@ -246,8 +247,7 @@ def parse_xml_data(xml_data: str) -> list:
                     "identifier": identifier,
                     "abstract_url": abstract_url,
                     "authors": authors,
-                    "primary_category": primary_category,
-                    "categories": categories,  # All categories
+                    "categories": categories,
                     "abstract": abstract,
                     "title": title,
                     "date": date,

--- a/services/parse_arxiv_summaries/tests/test_pas_lambda_handler.py
+++ b/services/parse_arxiv_summaries/tests/test_pas_lambda_handler.py
@@ -89,7 +89,6 @@ class TestLambdaHandler(unittest.TestCase):
                 "identifier": "test-identifier",
                 "abstract_url": "test-url",
                 "authors": [{"last_name": "Doe", "first_name": "John"}],
-                "primary_category": "AI",
                 "categories": ["AI"],
                 "abstract": "Test abstract",
                 "title": "Test Title",
@@ -141,7 +140,6 @@ class TestParseXMLData:
         assert result[0]["identifier"] == "oai:arXiv.org:1303.2033"
         assert result[0]["abstract_url"] == "http://arxiv.org/abs/1303.2033"
         assert result[0]["authors"] == [{"last_name": "Liepins", "first_name": "Vilnis"}]
-        assert result[0]["primary_category"] == "DS"
         assert result[0]["categories"] == ["DS", "IT"]
         assert result[0]["abstract"] == "Sample abstract"
         assert result[0]["title"] == "Extended Fourier analysis of signals"


### PR DESCRIPTION
Remove redundant field in parsed arXiv records